### PR TITLE
junitとhamcrestのバージョン記述をdependencyManagementに移動.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,18 @@
         <version>0.1.0</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>1.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -246,14 +258,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
testスコープ以外で参照したい場合があるため(nabalrch-test-support).