### PR TITLE
6系用の修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     <junit.additionalArgLine/>
     <ci.additionalArgLine />
     <junit.argLine>${junit.defaultArgLine} ${junit.additionalArgLine} ${ci.additionalArgLine}</junit.argLine>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.35</jmockit.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.1.4.jre6</version>
+          <version>42.1.4</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -126,7 +126,7 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.2.6.jre6</version>
+          <version>42.2.6</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.10.jre6</version>
+            <version>42.2.10</version>
         </dependency>
       </dependencies>
     </profile>
@@ -149,7 +149,7 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.2.19.jre6</version>
+          <version>42.2.19</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -418,32 +418,6 @@
         <version>6-NEXT-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
-      
-      <!-- Java 11以降で必要となるライブラリの定義 -->
-      <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>javax.activation-api</artifactId>
-        <version>1.2.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.activation</groupId>
-        <artifactId>javax.activation</artifactId>
-        <version>1.2.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <scope>test</scope>
-        <version>2.3.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <scope>test</scope>
-        <version>2.3.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
- コンパイルレベルを 1.8 に変更
- PostgreSQL の JDBC ドライバを Java 6 用から Java 8 用に変更
- Java 11 で必要になるライブラリ(activation, jaxb)の定義を削除
  - Jakarta EE 9 対応で Java SE 内のAPIには依存せずに Jakarta EE 9 対応版モジュールに直接依存するように修正するため