### PR TITLE
PostgreSQL 14.0 のテストが落ちるので Java 8 用のドライバで検証

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.2.24.jre6</version>
+          <version>42.2.24</version>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
以下のエラーが発生するので、エラーメッセージに従って試しに Java 8 版を使用する修正。

```
[INFO] Running nablarch.common.handler.TransactionManagementHandlerTransactionTimeoutTest
org.apache.commons.dbcp.SQLNestedException: Cannot create PoolableConnectionFactory (SCRAM認証はこのドライバではサポートされません。JDK8 以降かつ pgjdbc 42.2.0 以降(".jre"のバージョンではありません)が必要です。)
	at org.apache.commons.dbcp.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:1549)
	at org.apache.commons.dbcp.BasicDataSource.createDataSource(BasicDataSource.java:1388)
	at org.apache.commons.dbcp.BasicDataSource.getLogWriter(BasicDataSource.java:1098)
	at org.apache.commons.dbcp.BasicDataSourceFactory.createDataSource(BasicDataSourceFactory.java:350)
	at nablarch.test.support.db.datasource.DataSourceFactory.createObject(DataSourceFactory.java:52)
	at nablarch.test.support.db.datasource.DataSourceFactory.createObject(DataSourceFactory.java:13)
	at nablarch.core.repository.di.DiContainer.createComponent(DiContainer.java:414)
	at nablarch.core.repository.di.DiContainer.reload(DiContainer.java:224)
	at nablarch.core.repository.di.DiContainer.<init>(DiContainer.java:103)
	at nablarch.core.repository.di.DiContainer.<init>(DiContainer.java:90)
	at nablarch.test.support.db.helper.DatabaseTestRunner.run(DatabaseTestRunner.java:46)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:272)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:236)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:386)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:323)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:143)
Caused by: org.postgresql.util.PSQLException: SCRAM認証はこのドライバではサポートされません。JDK8 以降かつ pgjdbc 42.2.0 以降(".jre"のバージョンではありません)が必要です。
	at org.postgresql.core.v3.ConnectionFactoryImpl.doAuthentication(ConnectionFactoryImpl.java:767)
	at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:161)
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:213)
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:51)
	at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:225)
	at org.postgresql.Driver.makeConnection(Driver.java:465)
	at org.postgresql.Driver.connect(Driver.java:264)
	at org.apache.commons.dbcp.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:38)
	at org.apache.commons.dbcp.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:582)
	at org.apache.commons.dbcp.BasicDataSource.validateConnectionFactory(BasicDataSource.java:1556)
	at org.apache.commons.dbcp.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:1545)
	... 17 more
```