### PR TITLE
feat: jdk1.8以降でH2のバージョンが2.1.214に指定されるよう修正しました。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,40 @@
         </site>
       </distributionManagement>
     </profile>
+
+    <profile>
+      <id>h2-14</id>
+      <activation>
+        <jdk>[1.6,1.8)</jdk>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.191</version>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+
+    <profile>
+      <id>h2-21</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.1.214</version>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
     
     <profile>
       <id>postgres</id>
@@ -426,13 +460,6 @@
         <groupId>org.jmockit</groupId>
         <artifactId>jmockit</artifactId>
         <version>${jmockit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      
-      <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>2.1.214</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
jiraチケット
https://nablarch.atlassian.net/browse/NAB-468