### PR TITLE
H2のプロファイルからJDKによるアクティベーション設定を削除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,7 @@
     </profile>
 
     <profile>
-      <id>h2-14</id>
-      <activation>
-        <jdk>[1.6,1.8)</jdk>
-      </activation>
+      <id>h2-1</id>
       <dependencyManagement>
         <dependencies>
           <dependency>
@@ -126,10 +123,7 @@
     </profile>
 
     <profile>
-      <id>h2-21</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
+      <id>h2-2</id>
       <dependencyManagement>
         <dependencies>
           <dependency>


### PR DESCRIPTION
CI実行時JDKのバージョンによって自動的にプロファイルが切り替わるようにJDKでのアクティベーション設定を入れた。
しかし、CI環境ではJAVA_HOMEはJava8固定で、compilerプラグイン、surefireプラグインの実行時の設定でJDKのバージョンを切り替えているため、JDKによるプロファイルの切り替えがうまく動かなかった。（JAVA_HOMEに設定されているJava8だけを見てH2の2系のプロファイルが常に有効になってしまう）
https://github.com/nablarch/nablarch-parent/blob/5u21/pom.xml#L66

そのため、JDKによるアクティベーションの設定は削除し、CI実行時に明示的にプロファイルを指定するように変更した。