### PR TITLE
プロファイルによるdependencyManagementの切り替えがうまくいかなかったためpropertiesで上書く方式に変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.35</jmockit.version>
+    <h2.version>2.1.214</h2.version>
   </properties>
 
   <profiles>
@@ -110,32 +111,11 @@
 
     <profile>
       <id>h2-1</id>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.191</version>
-            <scope>test</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
+      <properties>
+        <h2.version>1.4.191</h2.version>
+      </properties>
     </profile>
 
-    <profile>
-      <id>h2-2</id>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>2.1.214</version>
-            <scope>test</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-    </profile>
-    
     <profile>
       <id>postgres</id>
       <dependencies>
@@ -488,6 +468,12 @@
         <artifactId>jaxb-impl</artifactId>
         <scope>test</scope>
         <version>2.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${h2.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
#25 、 #26 にてプロファイルによってdependencyManagementが切り替わるように指定したがうまくいかなかったため、propertiesでH2のバージョンを指定する方式に変更した。
デフォルトではJava8以上で使えるH2の2系を指定し、H2の2系が使えないJava6,7の環境ではプロファイル指定によってH2の1系が有効となるようにした。
ローカル環境にてnablarch-parentをインストールし、想定通りプロファイル切り替えによってH2のバージョンが切り替わることを確認済み。