### PR TITLE
surefire-pluginのバージョンアップ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.35</jmockit.version>
     <h2.version>2.1.214</h2.version>
+    <surefire.plugin.version>2.22.2</surefire.plugin.version>
   </properties>
 
   <profiles>
@@ -70,7 +71,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.20</version>
+            <version>${surefire.plugin.version}</version>
             <configuration>
               <jvm>${env.TEST_JDK}/bin/java</jvm>
               <argLine>
@@ -318,7 +319,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
+        <version>${surefire.plugin.version}</version>
         <configuration>
           <argLine>
             ${junit.argLine}


### PR DESCRIPTION
本モジュールの子プロジェクトでJUnit5(junit-jupiter)を依存に追加してもJUnit5のテストが動かず、JUnit4のテストだけが動いてしまった。
surefireプラグインのバージョンが古いとJUnit4のエンジンを優先してしまうようでJUnit5のテストが動かない。
バージョンアップすることで、JUnit5のエンジンが優先され、JUnit5のテストが動くようになる。
(既存のJUnit4テストはjunit-vintage-engineを使用することで引き続き実行可能。)

surefireプラグインの最新バージョンは3系だが、Java8以上となっているため２系の最新版である2.22.2とする。

https://maven.apache.org/surefire/maven-surefire-plugin/index.html
> Requirements: Maven 3.2.5 and JDK 1.8 or higher.
