### PR TITLE
feat: jacocoのバージョンを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmockit.version>1.35</jmockit.version>
+    <jacoco.version>0.8.8</jacoco.version>
     <h2.version>2.1.214</h2.version>
     <surefire.plugin.version>2.22.2</surefire.plugin.version>
     <!-- Jakarta EE 互換ライブラリのバージョン(ci = compatible implementation) -->
@@ -86,6 +87,7 @@
       <id>ci</id>
       <properties>
         <sonar.host.url>${env.SONAR_URL}</sonar.host.url>
+        <ci.additionalArgLine>-Djacoco-agent.destfile=${project.build.directory}/jacoco.exec</ci.additionalArgLine>
       </properties>
       <build>
         <plugins>
@@ -105,7 +107,7 @@
             <configuration>
               <jvm>${env.TEST_JDK}/bin/java</jvm>
               <argLine>
-                @{argLine} ${junit.argLine}
+                ${junit.argLine}
               </argLine>
             </configuration>
           </plugin>
@@ -359,12 +361,19 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>${jacoco.version}</version>
         <executions>
+          <!-- javaagent を使うと jmockit がエラーになるので Offline Instrumentation を使用する -->
           <execution>
-            <id>prepare-agent</id>
+            <id>default-instrument</id>
             <goals>
-              <goal>prepare-agent</goal>
+              <goal>instrument</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-restore-instrumented-classes</id>
+            <goals>
+              <goal>restore-instrumented-classes</goal>
             </goals>
           </execution>
         </executions>
@@ -621,6 +630,15 @@
       <artifactId>hamcrest-all</artifactId>
       <version>1.3</version>
       <scope>test</scope>
+    </dependency>
+
+    <!-- jacoco の Offline Instrumentation を使うために必要 -->
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>${jacoco.version}</version>
+      <scope>test</scope>
+      <classifier>runtime</classifier>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Java 17 に対応させるため jacoco のバージョンを最新化。
これによって jmockit と干渉するようになったため、 javaagent ではなく Offline Instrumentation を使うように修正。