### PR TITLE
feat: sonar-maven-plugin を最新化

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
           <plugin>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
-            <version>3.3.0.603</version>
+            <version>3.9.1.2184</version>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
SonarQube を Java 17 に対応している 9.9 に上げたことで、 sonar-maven-plugin のバージョンも上げる必要性が生じたので更新。