### PR TITLE
nablarch-fw-batch-eeをJava21でテストすると、Arquillianのエラーが発生するため、バージョンを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <jakarta-persistence.ci.version>4.0.1</jakarta-persistence.ci.version>
     <jakarta-rest-client.ci.version>6.2.2.Final</jakarta-rest-client.ci.version>
     <!-- Arquillian で使用する BOM のバージョン -->
-    <arquillian-bom.version>1.7.0.Final</arquillian-bom.version>
+    <arquillian-bom.version>1.8.0.Final</arquillian-bom.version>
     <payara-bom.version>6.2023.12</payara-bom.version>
     <shrinkwrap-resolver-bom.version>3.2.0</shrinkwrap-resolver-bom.version>
   </properties>


### PR DESCRIPTION
nablarch-fw-batch-ee（v6-develop）をJava21でテストすると、Arquillianのエラーが発生するため、arquillian-bom.versionを1.8.0.Finalに更新。