### PR TITLE
テストで使用するJDBCドライバをJDBC 4.2準拠バージョンに更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.2.19</version>
+          <version>42.7.2</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -169,7 +169,7 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.2.24</version>
+          <version>42.7.2</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -184,7 +184,7 @@
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
-          <version>42.5.4</version>
+          <version>42.7.2</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <dependency>
           <groupId>com.microsoft.sqlserver</groupId>
           <artifactId>mssql-jdbc</artifactId>
-          <version>7.4.1.jre8</version>
+          <version>12.6.1.jre11</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -271,7 +271,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>8.2.1.jre8</version>
+            <version>12.6.1.jre11</version>
             <scope>test</scope>
         </dependency>
       </dependencies>
@@ -286,7 +286,7 @@
         <dependency>
           <groupId>com.microsoft.sqlserver</groupId>
           <artifactId>mssql-jdbc</artifactId>
-          <version>12.2.0.jre8</version>
+          <version>12.6.1.jre11</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -135,36 +135,6 @@
     </profile>
 
     <profile>
-      <id>postgres</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.postgresql</groupId>
-          <artifactId>postgresql</artifactId>
-          <version>42.1.4</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <properties>
-        <junit.additionalArgLine.db-profile>-Ddb-profile=postgres</junit.additionalArgLine.db-profile>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>postgres115</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.postgresql</groupId>
-          <artifactId>postgresql</artifactId>
-          <version>42.2.6</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <properties>
-        <junit.additionalArgLine.db-profile>-Ddb-profile=postgres115</junit.additionalArgLine.db-profile>
-      </properties>
-    </profile>
-
-    <profile>
       <id>postgres122</id>
       <dependencies>
         <dependency>
@@ -224,21 +194,6 @@
     </profile>
 
     <profile>
-      <id>oracle</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.oracle</groupId>
-          <artifactId>ojdbc6</artifactId>
-          <version>11.2.0.4.0</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <properties>
-        <junit.additionalArgLine.db-profile>-Ddb-profile=oracle</junit.additionalArgLine.db-profile>
-      </properties>
-    </profile>
-
-    <profile>
       <id>oracle19c</id>
       <dependencies>
         <dependency>
@@ -277,21 +232,6 @@
           <version>23.2.0.0</version>
         </dependency>
       </dependencies>
-    </profile>
-
-    <profile>
-      <id>db2</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.ibm.db2</groupId>
-          <artifactId>db2jcc4</artifactId>
-          <version>10.5</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <properties>
-        <junit.additionalArgLine.db-profile>-Ddb-profile=db2</junit.additionalArgLine.db-profile>
-      </properties>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -299,8 +299,8 @@
       <dependencies>
         <dependency>
           <groupId>com.ibm.db2</groupId>
-          <artifactId>db2jcc4</artifactId>
-          <version>11.5</version>
+          <artifactId>jcc</artifactId>
+          <version>11.5.9.0</version>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
## 背景

nablarch-core-jdbcおよびnablarch-common-daoにDate And Time APIのテストを実装したところ、現在テストで使用しているJDBドライバがJDBC 4.2準拠していないバージョンのために失敗していた。

## 対応概要

Oracle分は #44 で対応済みのため、それ以外の分について以下のとおり対応した。
また、v6系ではテスト対象外となっているDBバージョンのプロファイルが定義されたままであったため、そちらはバージョンを更新せずに削除した。

### DB2

- [ドキュメントでは`11.5.4`からJDBC 4.2準拠](https://www.ibm.com/docs/ja/db2/11.5?topic=dscde-jdbc-sqlj-driver-enhancements-3)とあるが、少し古いバージョンを使用する必要性も無かったため最新の`11.5.9`に変更
  - テスト環境は 11.5 のみであるため問題無しと判断した
- Maven CentralからJDBCドライバを取得できるようだったので、依存関係の定義を変更した
  - 厳密には[ドキュメント上だとIBMのサイトからダウンロードするように案内している](https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads)のだが、Maven Centralも最近更新されているようだったので問題無しと判断した

### PostgreSQL

- [JDBCドライバのDownloadページ](https://jdbc.postgresql.org/download/)を見ると`42.6.1`以上が対象のようで、少し古いバージョンを使用する必要性も無かったため最新の`42.7`に変更
  - ドキュメントでは[現在の最新バージョンでPostgreSQL 8.2以降をサポートしている](https://jdbc.postgresql.org/documentation/)とあるため問題無しと判断した

### SQL Server

- ドキュメントからJDBC 4.2準拠の記述は見つけられなかったが、[最新の`12.6`からJava 21をサポートしている](https://learn.microsoft.com/ja-jp/sql/connect/jdbc/release-notes-for-the-jdbc-driver?view=sql-server-ver16)ようだったので、テスト環境で使用するJava 21を考慮して`12.6`に変更
  - [ドキュメントのサポート表](https://learn.microsoft.com/ja-jp/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix?view=sql-server-ver16#sql-version-compatibility)では`12.6`でSQL Server 2017〜をすべてサポートしていたため問題無しと判断した

