### PR TITLE
postgres122プロファイルのJDBCドライババージョンアップが漏れていたため修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.10</version>
+            <version>42.7.2</version>
         </dependency>
       </dependencies>
       <properties>


### PR DESCRIPTION
## 背景

#45 でPostgreSQLのJDBCドライバをバージョンアップしたが、postgres122プロファイルだけ対応が漏れていた。

## 対応概要

他プロファイルと同じバージョンを使用するように対応。