### PR TITLE
OSSRHからCentral Publisher Portalへ移行

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,17 +351,7 @@
     </profile>
 
     <profile>
-      <id>ossrh</id>
-      <distributionManagement>
-        <repository>
-          <id>nablarch.staging</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-          <id>nablarch.snapshot</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
+      <id>central</id>
       <build>
         <plugins>
           <plugin>
@@ -377,6 +367,15 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
OSSRHのサービス終了に向けて、Maven Centralへのデプロイ方法をCentral Publisher Portalへ移行する。

主な変更点は以下のとおり。

- Profile名を`ossrh`から`central`に変更
  - 必須の変更ではないが、OSSRHの名称を残しても今後わかりにくくなるだけなので変更する
- 名称変更したProfileの修正
  - `distributionManagement`の削除
    - デプロイ先のidは`ossrh`から`central`となるが、`central`については明示的な定義は不要
    - SNAPSHOTリポジトリは使用していないので削除
  - Central Publishing Mavenプラグインを追加
    - `mvn deploy`コマンドでCentral Publisher Portalにデプロイするプラグイン
    - デプロイ時にのみ使うため、central Profileにのみ追加

一時的に`version`および`depedencyManagement`に記載されている`nablarch-bom`の`version`を6u4に変更し、Central Publisher Potalへデプロイできることを確認。

```shell
$ mvn clean deploy -DskipTests -P central
```

![image](https://github.com/user-attachments/assets/aaeadbda-bf76-4246-858a-b803f6d4d478)
